### PR TITLE
Use a much simpler way to generate the colon-separated hex format

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,8 @@ ik_pub = some_bundle.ik
 showQRCode(ik_pub)
 
 # ...or create a hex byte representation
-# Wanted format: 01:23:45:67:89:AB:CD:EF
-# This is surprisingly tricky:
-import codecs
-import re
-ik_pub_hex = codecs.getencoder("hex")(ik_pub)[0].decode("US-ASCII").upper()
-ik_pub_hex = ":".join(re.findall("..?", ik_pub_hex))
+# Wanted format: 01:23:45:67:89:ab:cd:ef
+ik_pub_hex = ":".join("{:02x}".format(octet) for octet in ik_pub)
 ```
 
 ### 7. A note about asynchronism


### PR DESCRIPTION
This assumes that ``ik_pub`` is a ``bytes`` object, otherwise this will go down the drain. Removes the need for ``re`` and ``codecs``.

FWIW, using ``binascii.b2a_hex`` would be preferred over explicitly invoking ``codecs`` I guess.

Example:
```python
>>> import random
>>> noise = random.getrandbits(128).to_bytes(16, "little")
>>> ":".join("{:02x}".format(octet) for octet in noise)
'10:76:1f:19:21:56:15:0e:33:f6:92:bf:ca:b2:ab:19'
>>> import binascii
>>> binascii.b2a_hex(noise)
b'10761f192156150e33f692bfcab2ab19'
>>> import codecs
>>> import re
>>> noise_hex = codecs.getencoder("hex")(noise)[0].decode("US-ASCII").upper()
>>> noise_hex = ":".join(re.findall("..?", noise_hex))
>>> noise_hex
'10:76:1F:19:21:56:15:0E:33:F6:92:BF:CA:B2:AB:19'
```

Note that this PR introduces *lower* case format, which I personally find easier to read. To change it to upper case, change the ``x`` to a ``X`` (or let me know so that I can fix it).