### PR TITLE
JSONFileStorage: Prevent from choking on non-ascii characters in JIDs

### DIFF
--- a/omemo/implementations/jsonfilestorage.py
+++ b/omemo/implementations/jsonfilestorage.py
@@ -59,7 +59,7 @@ class JSONFileStorage(Storage):
 
     @staticmethod
     def getHashForBareJID(bare_jid):
-        digest = hashlib.sha256(bare_jid.encode("US-ASCII")).digest()
+        digest = hashlib.sha256(bare_jid.encode("UTF-8")).digest()
 
         return base64.b32encode(digest).decode("US-ASCII")
 


### PR DESCRIPTION
While I doubt this small change would be subject to copyright, you are free to re-license.

Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>