### PR TITLE
Replace typing_extensions with direct typing imports

### DIFF
--- a/examples/btbv_session_manager.py
+++ b/examples/btbv_session_manager.py
@@ -1,8 +1,6 @@
 import abc
 import enum
-from typing import FrozenSet, Optional, Set
-
-from typing_extensions import assert_never
+from typing import FrozenSet, Optional, Set, assert_never
 
 import omemo
 

--- a/omemo/session_manager.py
+++ b/omemo/session_manager.py
@@ -5,8 +5,7 @@ import itertools
 import logging
 import secrets
 from typing import Awaitable, Dict, FrozenSet, List, NamedTuple, Optional, Set, Tuple, Type, TypeVar, Union, \
-    cast
-from typing_extensions import assert_never
+    assert_never, cast
 
 try:
     # One of the asynchronous frameworks supported other than asyncio.

--- a/omemo/types.py
+++ b/omemo/types.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import enum
-from typing import Dict, FrozenSet, List, Mapping, NamedTuple, Optional, Tuple, Union
-from typing_extensions import TypeAlias
+from typing import Dict, FrozenSet, List, Mapping, NamedTuple, Optional, Tuple, TypeAlias, Union
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ license-files = [ "LICENSE" ]
 requires-python = ">= 3.10"
 dependencies = [
     "XEdDSA>=1.0.0,<2",
-    "typing-extensions>=4.3.0"
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,6 +1,6 @@
 import twomemo
 import oldmemo
-from typing_extensions import Final
+from typing import Final
 
 
 __all__ = [

--- a/tests/migration.py
+++ b/tests/migration.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree as ET
 import oldmemo
 import oldmemo.etree
 from oldmemo.migrations import LegacyStorage, OwnData, State, Session, Trust
-from typing_extensions import Final
+from typing import Final
 
 import omemo
 

--- a/tests/session_manager_impl.py
+++ b/tests/session_manager_impl.py
@@ -1,7 +1,5 @@
 import enum
-from typing import Dict, FrozenSet, List, Optional, Tuple, Type
-
-from typing_extensions import NamedTuple, assert_never
+from typing import Dict, FrozenSet, List, NamedTuple, Optional, Tuple, Type, assert_never
 
 import omemo
 


### PR DESCRIPTION
All of these imports should have made it into the typing module in the many Python versions since thoe got introduced, let’s remove the extension package then.